### PR TITLE
✨ Allow `ignore` option to accept RegExp

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ export function shouldHandle(
   href: string,
   element: HTMLAnchorElement,
   event: MouseEvent,
-  ignore?: string[],
+  ignore?: (string | RegExp)[],
 ): boolean;
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -145,8 +145,12 @@ export function shouldHandle(href, element, event, ignore = []) {
    * We can optionally declare some paths as ignored,
    * or "let the browser do its default thing,
    * because there is other server-based routing to worry about"
+   * 
+   * `ignore` is an array of either:
+   * - string elements representing explicit paths
+   * - RegExp elements to match parts of URL
    */
-  if (ignore.includes(url.pathname)) return false;
+  if (ignore.some((element) => url.pathname.match(element))) return false;
 
   return true;
 }


### PR DESCRIPTION
✨ Update the `ignore` option to handle `RegExp` and not just literal string comparison

Fix Feature request - allow ignore to accept Regex #13